### PR TITLE
responseの作成関数化、Exception、DEBUGの修正

### DIFF
--- a/srcs/server/HTTPRequest.cpp
+++ b/srcs/server/HTTPRequest.cpp
@@ -103,7 +103,7 @@ void			HTTPRequest::setMode(const enum response_mode mode)
 
 void HTTPRequest::print(void)
 {
-	std::cout << "----------------- HTTPRequest Result -----------------" << std::endl;
+	std::cout << "----------------- HTTPRequest Parse Result -----------------" << std::endl;
 	std::cout << "method: " << this->_method << std::endl;
 	std::cout << "uri: " << this->_uri << std::endl;
 	std::cout << "protocol_version: " << this->_version << std::endl;

--- a/srcs/server/HTTPRequestParse.cpp
+++ b/srcs/server/HTTPRequestParse.cpp
@@ -62,7 +62,9 @@ void HTTPRequestParse::parse(char *buffer)
 	}
 	readRequestLine(line);
 	readHeaders(bufferStream);
-	_request.print();
+	#if DEBUG
+		_request.print();
+	# endif
 	bufferStream.clear();
 	bufferStream.str("");
 }
@@ -71,7 +73,7 @@ void HTTPRequestParse::readRequestLine(std::string &line)
 {
 	std::vector<std::string> request_line = split(line, ' ');
 	if (request_line.size() != 3)
-		log_exit("request_line.size() != 3", __LINE__, __FILE__, errno);
+		throw std::runtime_error("request line parse error");
 	this->_request.setMethod(request_line[0]);
 	this->_request.setUri(request_line[1]);
 	this->_request.setVersion(request_line[2]);

--- a/srcs/server/HTTPResponse.cpp
+++ b/srcs/server/HTTPResponse.cpp
@@ -1,6 +1,6 @@
 #include "HTTPResponse.hpp"
 
-HTTPResponse::HTTPResponse() : _version(HTTP_VERSION), _statusCode(STATUS_200), keepAlive(true), _contentLength(0)
+HTTPResponse::HTTPResponse() : _version(HTTP_VERSION), _statusCode(STATUS_200), _keepAlive(true), _contentLength(0)
 {
 	setStatusMessageMap();
 	setStatusMessage(_statusMessageMap[_statusCode]);
@@ -35,7 +35,7 @@ const std::string &HTTPResponse::getStatusLine() const
 
 const bool &HTTPResponse::getKeepAlive() const
 {
-	return this->keepAlive;
+	return this->_keepAlive;
 }
 
 const size_t &HTTPResponse::getContentLength() const
@@ -86,7 +86,7 @@ void HTTPResponse::setStatusLine(void)
 
 void HTTPResponse::setKeepAlive(const bool &keepAlive)
 {
-	this->keepAlive = keepAlive;
+	this->_keepAlive = keepAlive;
 }
 
 void HTTPResponse::setContentLength(const size_t &contentLength)
@@ -217,34 +217,25 @@ bool HTTPResponse::isFile(struct stat &stat)
 	return S_ISREG(stat.st_mode);
 }
 
-// TODO : handleNormalRequestに変更済み、頃合いを見て削除
-std::string HTTPResponse::makeResponseMessage(HTTPRequest &request)
+void HTTPResponse::makeResponseMessage(HTTPRequest &request)
 {
-	std::ifstream ifs;
-	std::string responseMessage;
 	std::string method = request.getMethod();
-	if (method == "GET")
-		makeGetResponseBody(request);
-	else if (method == "POST")
-		makePostResponseBody(request);
-	else if (method == "DELETE")
-		makeDeleteResponseBody(request);
-	else
-		responseMessage = "HTTP/1.1 501 Not Implemented\r\n";
 	setStatusLine();
-	if (keepAlive)
+	if (_keepAlive)
 		setHeader("Connection", "keep-alive");
 	else
 		setHeader("Connection", "close");
 	setHeader("Date", getDateTimestamp());
 	setHeader("Server", SERVER_NAME);
 	setContentLength(_body.size());
-	setHeader("Content-Length", ft_stoi(_contentLength));
-	responseMessage += _statusLine;
+	if (_contentLength > 0)
+		setHeader("Content-Length", ft_stoi(_contentLength));
+	_responseMessage += _statusLine;
 	for (std::map<std::string, std::string>::iterator it = _headers.begin(); it != _headers.end(); it++) {
-		responseMessage += it->first + ": " + it->second + CRLF;
+		_responseMessage += it->first + ": " + it->second + CRLF;
 	}
-	responseMessage += CRLF;
-	responseMessage += _body;
-	return responseMessage;
+	if (_body.size() > 0) {
+		_responseMessage += CRLF;
+		_responseMessage += _body;
+	}
 }

--- a/srcs/server/HTTPResponse.hpp
+++ b/srcs/server/HTTPResponse.hpp
@@ -23,7 +23,7 @@ class HTTPResponse
 		HTTPStatusCode _statusCode;
 		std::string _statusMessage;
 		std::string _statusLine;
-		bool keepAlive;
+		bool _keepAlive;
 		size_t _contentLength;
 		std::map<std::string, std::string> _headers;
 		std::string _body;
@@ -65,12 +65,11 @@ class HTTPResponse
 		void handleRedirectRequest(HTTPRequest &request);
 		void handleErrorResponse(HTTPRequest &request);
 
-		std::string makeResponseMessage(HTTPRequest &request);
 		void makeFileBody(const std::string &path);
 		void makeGetResponseBody(HTTPRequest &request);
 		void makePostResponseBody(HTTPRequest &request);
 		void makeDeleteResponseBody(HTTPRequest &request);
-		std::string makeResponseStatusLine(void);
+		void makeResponseMessage(HTTPRequest &request);
 
 		std::string getDateTimestamp(void) const;
 		std::string getTimeStampForPost(void) const;

--- a/srcs/server/HTTPResponseDELETE.cpp
+++ b/srcs/server/HTTPResponseDELETE.cpp
@@ -9,25 +9,20 @@ void HTTPResponse::makeDeleteResponseBody(HTTPRequest &request)
 	path = "./www" + path;
 	if (isFileExist(path, request.getStat()) == false) {
 		_statusCode = STATUS_404;
-		_responseMessage = "HTTP/1.1 404 Not Found\r\n";
 		return ;
 	} else if (isFile(*request.getStat())) {
 		if ((std::remove(path.c_str()) != 0)) {
 			_statusCode = STATUS_403;
-			_responseMessage = "HTTP/1.1 403 Forbidden\r\n";
 			return ;
 		} else {
 			_statusCode = STATUS_204;
-			_responseMessage = "HTTP/1.1 204 No Content\r\n";
 			return ;
 		}
 	} else if (isDirectory(*request.getStat())) {
 		_statusCode = STATUS_403;
-		_responseMessage = "HTTP/1.1 403 Forbidden\r\n";
 		return ;
 	} else {
 		_statusCode = STATUS_500;
-		_responseMessage = "HTTP/1.1 500 Internal Server Error\r\n";
 		return ;
 	}
 }

--- a/srcs/server/HTTPResponseGET.cpp
+++ b/srcs/server/HTTPResponseGET.cpp
@@ -10,7 +10,7 @@ void HTTPResponse::makeGetResponseBody(HTTPRequest &request)
 	// TODO : configの設定によって、pathを変更する ./www以外にも対応できるように
 	if (isFileExist("./www" + path, request.getStat()) == false) {
 		_statusCode = STATUS_404;
-		makeFileBody("./www/error/404.html");
+		makeFileBody("./www/error_page/404.html");
 		return ;
 	} else if (isFile(*request.getStat())) {
 		makeFileBody("./www" + path);
@@ -19,6 +19,6 @@ void HTTPResponse::makeGetResponseBody(HTTPRequest &request)
 		makeFileBody(std::string("./www" + path + "/index.html"));
 	} else {
 		_statusCode = STATUS_404;
-		makeFileBody("./www/error/404.html");
+		makeFileBody("./www/error_page/404.html");
 	}
 }

--- a/srcs/server/HTTPResponseHandle.cpp
+++ b/srcs/server/HTTPResponseHandle.cpp
@@ -27,25 +27,13 @@ void HTTPResponse::handleNormalRequest(HTTPRequest &request)
 	std::string method = request.getMethod();
 	if (method == "GET") {
 		makeGetResponseBody(request);
-		setStatusLine();
-		if (keepAlive)
-			setHeader("Connection", "keep-alive");
-		else
-			setHeader("Connection", "close");
-		setHeader("Date", getDateTimestamp());
-		setHeader("Server", SERVER_NAME);
-		setContentLength(_body.size());
-		setHeader("Content-Length", ft_stoi(_contentLength));
-		_responseMessage += _statusLine;
-		for (std::map<std::string, std::string>::iterator it = _headers.begin(); it != _headers.end(); it++) {
-			_responseMessage += it->first + ": " + it->second + CRLF;
-		}
-		_responseMessage += CRLF;
-		_responseMessage += _body;
+		makeResponseMessage(request);
 	} else if (method == "POST") {
 		makePostResponseBody(request);
+		makeResponseMessage(request);
 	} else if (method == "DELETE") {
 		makeDeleteResponseBody(request);
+		makeResponseMessage(request);
 	}
 	else {
 		// TODO : error message

--- a/srcs/server/HTTPResponsePOST.cpp
+++ b/srcs/server/HTTPResponsePOST.cpp
@@ -26,11 +26,9 @@ void HTTPResponse::makePostResponseBody(HTTPRequest &request)
 	if (!ofs.is_open())
 	{
 		_statusCode = STATUS_500;
-		_responseMessage = "HTTP/1.1 500 Internal Server Error\r\n";
 		return;
 	}
 	ofs << body;
 	ofs.close();
 	_statusCode = STATUS_201;
-	_responseMessage = "HTTP/1.1 201 Created\r\n";
 }


### PR DESCRIPTION
##  Task・Issue
- #17 

## 実装したこと
- 実装方針・参考資料など
- parseやレスポンスのエラー時にthrowを投げたら、catch出来るように変更
- 現時点ではthrowしている場所が一箇所しか無いが、今後throwすればcatch出来るはず
- レスポンスメッセージの作成方式を、関数化してまとめた。
- デバッグをキレイに
- ステータスコードを設定して、その後にsetStatusLineによてメッセージを設定できるようにした。

## 動作確認
- テストケース・スクリーンショットなど
- 試しに無理やりthrowしたら、catchしてエラーを受け取って、インターナルサーバーエラーを返すことに成功
