### PR TITLE
21 poll

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@ SRC = main.cpp
 
 CONFIG = ConfigParse.cpp Config.cpp ServerConfig.cpp
 
-SERVER = Server.cpp HTTPRequestParse.cpp  HTTPRequest.cpp HTTPResponse.cpp \
+SERVER = Server.cpp HTTPRequestParse.cpp  HTTPRequest.cpp HTTPResponse.cpp Client.cpp \
 	HTTPResponseGET.cpp HTTPResponsePOST.cpp  HTTPResponseDELETE.cpp HTTPResponseHandle.cpp
 
-UTILS = ft_memset.cpp error.cpp nonBlockingFd.cpp ft_to_string.cpp isHex.cpp
+UTILS = ft_memset.cpp error.cpp nonBlockingFd.cpp ft_to_string.cpp isHex.cpp ft_stoi.cpp
 
 CGI = CGI.cpp
 
@@ -85,6 +85,7 @@ dummy :
 
 debug : CXXFLAGS += -D DEBUG -fsanitize=address
 debug : re
+	./$(NAME)
 
 leak :
 	while true; do leaks -q $(NAME); sleep 1; done

--- a/srcs/exception/ServerError.hpp
+++ b/srcs/exception/ServerError.hpp
@@ -17,3 +17,12 @@ class InternalServerError : public std::exception
 			return ("Internal Server Error");
 		}
 };
+
+class HTTPRequestPayloadTooLargeError: public std::exception
+{
+	public:
+		virtual const char *what() const throw()
+		{
+			return ("Payload Too Large");
+		}
+};

--- a/srcs/server/Client.cpp
+++ b/srcs/server/Client.cpp
@@ -1,0 +1,109 @@
+#include "Client.hpp"
+
+
+Client::Client(int client_fd, int server_fd) : _client_fd(client_fd), _server_fd(server_fd)
+{
+}
+
+Client::~Client(void)
+{
+}
+
+int Client::getClientFd(void) const
+{
+	return _client_fd;
+}
+
+int Client::getServerFd(void) const
+{
+	return _server_fd;
+}
+
+void Client::setClientFd(int client_fd)
+{
+	_client_fd = client_fd;
+}
+
+void Client::setServerFd(int server_fd)
+{
+	_server_fd = server_fd;
+}
+
+
+int Client::requestProcess(HTTPRequest &request)
+{
+	char buffer[_buffer_size];
+	HTTPRequestParse request_parse(request);
+	ssize_t n = recv(_client_fd, buffer, sizeof(buffer) - 1, 0);
+	if (n < 0)
+	{
+		log_print("recv", __LINE__, __FILE__, errno);
+		return -1;
+	}
+	buffer[n] = '\0';
+	#if DEBUG
+		std::cout << "#### [ DEBUG ] request message ####" << std::endl << buffer << std::endl << "##########" << std::endl;
+	#endif
+	request_parse.parse(buffer);
+	return 0;
+}
+
+void Client::responseProcess(HTTPRequest &request, HTTPResponse &response)
+{
+	response.selectResponse(request);
+}
+
+int Client::sendResponse(std::string &responseMessage)
+{
+	ssize_t send_n = send(_client_fd, responseMessage.c_str(), responseMessage.size(), 0);
+	if (send_n < 0)
+	{
+		log_print("send", __LINE__, __FILE__, errno);
+		return -1;
+	}
+	return 0;
+}
+
+int Client::clientProcess()
+{
+	HTTPRequest request;
+	HTTPResponse response;
+	HTTPRequestParse request_parse(request);
+	std::string responseMessage;
+
+	try {
+		if (requestProcess(request) < 0)
+			return -1;
+		responseProcess(request, response);
+	} catch (HTTPRequestParseError &e) {
+		std::cerr << e.what() << std::endl;
+		response.setStatusCode(STATUS_400);
+		response.setStatusLine();
+		responseMessage = response.getStatusLine();
+	} catch (InternalServerError &e) {
+		std::cerr << e.what() << std::endl;
+		response.setStatusCode(STATUS_500);
+		response.setStatusLine();
+		responseMessage = response.getStatusLine();
+	} catch (HTTPRequestPayloadTooLargeError &e) {
+		std::cerr << e.what() << std::endl;
+		response.setStatusCode(STATUS_413);
+		response.setStatusLine();
+		responseMessage = response.getStatusLine();
+	} catch (std::exception &e) {
+		std::cerr << e.what() << std::endl;
+		response.setStatusCode(STATUS_500);
+		response.setStatusLine();
+		responseMessage = response.getStatusLine();
+	}
+	responseMessage = response.getResponseMessage();
+	#if DEBUG
+		std::cout << "##### [ DEBUG ] response message ####" << std::endl << responseMessage << std::endl << "##########" << std::endl;
+	#endif
+	if (sendResponse(responseMessage) < 0)
+		return -1;
+	return 0;
+	# if DEBUG
+		std::cout << "==================================================" << std::endl;
+	# endif
+}

--- a/srcs/server/Client.hpp
+++ b/srcs/server/Client.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <unistd.h>
+#include <sys/socket.h>
+
+#include "HTTPRequest.hpp"
+#include "HTTPRequestParse.hpp"
+#include "HTTPResponse.hpp"
+#include "Webserv.hpp"
+
+# define BUFFER_SIZE			8192
+
+class Client
+{
+	private :
+		DISALLOW_COPY_AND_ASSIGN(Client);
+		int _client_fd;
+		int _server_fd;
+		static const size_t _buffer_size = BUFFER_SIZE;
+	public :
+		Client(int client_fd, int server_fd);
+		~Client(void);
+
+		int getClientFd(void) const;
+		int getServerFd(void) const;
+		void setClientFd(int client_fd);
+		void setServerFd(int server_fd);
+
+		int clientProcess();
+		int requestProcess(HTTPRequest &request);
+		void responseProcess(HTTPRequest &request, HTTPResponse &response);
+		int sendResponse(std::string &responseMessage);
+};

--- a/srcs/server/HTTPRequestParse.cpp
+++ b/srcs/server/HTTPRequestParse.cpp
@@ -105,6 +105,8 @@ void HTTPRequestParse::parseChunkedBody(std::stringstream &ss)
 	}
 	if (!body.empty())
 		this->_request.setBody(body);
+	if (body.size() > MAX_BODY_SIZE)
+		throw HTTPRequestPayloadTooLargeError();
 }
 
 void HTTPRequestParse::parseNormalBody(std::stringstream &ss)
@@ -119,6 +121,8 @@ void HTTPRequestParse::parseNormalBody(std::stringstream &ss)
 	}
 	if (!body.empty())
 		this->_request.setBody(body);
+	if (body.size() > MAX_BODY_SIZE)
+		throw HTTPRequestPayloadTooLargeError();
 }
 
 void HTTPRequestParse::readHeaders(std::stringstream &ss)

--- a/srcs/server/HTTPRequestParse.hpp
+++ b/srcs/server/HTTPRequestParse.hpp
@@ -9,6 +9,8 @@
 #include "utils.hpp"
 #include "Webserv.hpp"
 
+// TODO : config の設定を読み込む
+#define MAX_BODY_SIZE 8192
 class HTTPRequest;
 
 class HTTPRequestParse

--- a/srcs/server/Server.hpp
+++ b/srcs/server/Server.hpp
@@ -17,13 +17,13 @@
 #include "Webserv.hpp"
 #include "HTTPRequestParse.hpp"
 #include "HTTPResponse.hpp"
+#include "Client.hpp"
 #include "utils.hpp"
 #include "Config.hpp"
 
 # define SERVER_PORT			4242
 # define SERVER_PORT_STR		"4242"
 # define QUEUE_LENGTH			5
-# define MAX_EVENTS				10
 # define BUFFER_SIZE			8192
 # define MAX_CLIENTS			6
 
@@ -36,24 +36,27 @@
 class Server
 {
 	private:
-		int				_server_fd;
+		std::map<std::string, int>	_server_fds; // PORT_STR, server_fd
 		struct addrinfo _hints;
 		struct addrinfo *_res;
-		struct pollfd				fds_[MAX_CLIENTS + 1];
+		struct pollfd				fds_[MAX_CLIENTS];
 		char			_buffer[BUFFER_SIZE];
 		HTTPRequest		_request;
 		Config			_config;
 		DISALLOW_COPY_AND_ASSIGN(Server);
 
-		void	initServerAddr(void);
-		void	createSocket(void);
-		void	bindSocket(void);
-		void	listenSocket(void);
+		void setPortAndServerFd(std::string &port, int server_fd);
+
+		void	initServerAddr(std::string &port);
+		void	createSocket(std::string &port);
+		void	bindSocket(int &server_fd);
+		void	listenSocket(int &server_fd);
 		void	pollInit(void);
 		void	mainLoop(void);
-		int		acceptSocket(void);
+		int		acceptSocket(int &server_fd);
 		void	clientProcess(int client_fd);
 		void	parentProcess(pid_t pid);
+		void	closeServerFds(void);
 
 	public:
 		Server(void);

--- a/srcs/utils/error.cpp
+++ b/srcs/utils/error.cpp
@@ -8,3 +8,11 @@ void log_exit(const char *msg, int line, const char *file, int error)
 	std::cerr << "-- " << strerror(error) << " --" << std::endl;
 	std::exit(EXIT_FAILURE);
 }
+
+void log_print(const char *msg, int line, const char *file, int error)
+{
+	std::cerr << RED << "Error: " << msg << END
+		<< " (line : " << UNDERLINE << line << END <<
+		", file : "<< UNDERLINE << file << END << ")" << std::endl;
+	std::cerr << "-- " << strerror(error) << " --" << std::endl;
+}

--- a/srcs/utils/ft_stoi.cpp
+++ b/srcs/utils/ft_stoi.cpp
@@ -1,0 +1,9 @@
+#include "utils.hpp"
+
+int ft_stoi(const std::string &str)
+{
+	std::stringstream ss(str);
+	int result;
+	ss >> result;
+	return (result);
+}

--- a/srcs/utils/nonBlockingFd.cpp
+++ b/srcs/utils/nonBlockingFd.cpp
@@ -1,8 +1,6 @@
 #include "utils.hpp"
 
-
-// TODO : 使い方については、さらに調べる。
-void setNonBlockingFd(int fd)
+void setNonBlockingAndCloseOnExec(int fd)
 {
 	int flag = fcntl(fd, F_GETFL);
 	if (flag < 0) {
@@ -14,5 +12,24 @@ void setNonBlockingFd(int fd)
 		if (fcntl(fd, F_SETFD, FD_CLOEXEC) < 0) {
 			log_exit("fcntl/F_SETFD", __LINE__, __FILE__, errno);
 		}
+	}
+}
+
+void setNonBlockingFd(int fd)
+{
+	int flag = fcntl(fd, F_GETFL);
+	if (flag < 0) {
+		log_exit("fcntl", __LINE__, __FILE__, errno);
+	} else {
+		if (fcntl(fd, F_SETFL, flag | O_NONBLOCK) < 0) {
+			log_exit("fcntl/F_SETFL", __LINE__, __FILE__, errno);
+		}
+	}
+}
+
+void setCloseOnExec(int fd)
+{
+	if (fcntl(fd, F_SETFD, FD_CLOEXEC) < 0) {
+		log_exit("fcntl/F_SETFD", __LINE__, __FILE__, errno);
 	}
 }

--- a/srcs/utils/utils.hpp
+++ b/srcs/utils/utils.hpp
@@ -8,6 +8,10 @@
 
 void	*ft_memset(void *s, int c, size_t n);
 void	log_exit(const char *msg, int line, const char *file, int error);
+void	log_print(const char *msg, int line, const char *file, int error);
+void	setNonBlockingAndCloseOnExec(int fd);
+void	setCloseOnExec(int fd);
 void	setNonBlockingFd(int fd);
-std::string ft_to_string(size_t number);
+std::string	ft_to_string(size_t number);
+int		ft_stoi(const std::string &str);
 bool	isHex(const std::string &str);

--- a/tests/test.py
+++ b/tests/test.py
@@ -3,12 +3,17 @@ import requests
 url = 'http://localhost:4242'
 
 # # GET
-url += "/index.html"
+url += "/empty.html"
 response = requests.get(url)
 
 # POST
 # data = {'key1': 'value1'}
 # response = requests.post(url, data=data)
+
+# POST ファイル転送
+# with open('hoge.dummy', 'rb') as f:
+# 	file_data = f.read()
+# response = requests.post(url, data=file_data)
 
 # DELETE
 # url = 'http://localhost:4242/delete.html'


### PR DESCRIPTION
## Task・Issue
- #21 
-


## 実装したこと
- 実装方針・参考資料など
- pollを使って複数ポートに対応、4242と4243の定数で指定。
- マックスは6ポートまでに設定してある。マックスはdefineで決めているので、Configの方で設定を超えてきたらエラーにすれば良いと思う。
- Clientクラスの作成、recv, sendなどのクライアントのfdを使用するものを移行
- exitやfdのcloseをServerでしたいので、Clientクラスの関数ではexitせずにlog_printしてエラー値を返す。
- ft_stoiやblockingfd関数の追加
- body sizeを定数でおいて、超えた場合に413

## 動作確認
- テストケース・スクリーンショットなど
- 4242, 4243ポートでテスト→クリア
- body sizeを変更し、超えた場合にエラー→クリア
