### PR TITLE
[Add] redirectを定数で実装

### DIFF
--- a/srcs/server/HTTPRequestParse.cpp
+++ b/srcs/server/HTTPRequestParse.cpp
@@ -158,7 +158,7 @@ void HTTPRequestParse::searchLocation(void)
 		return ;
 	}
 	std::vector<std::string> uri_split = split(uri, '/');
-	if (uri_split.size() < 2)
+	if (uri_split.size() < 2 && uri[uri.size() - 1] != '/')
 	{
 		this->_request.setLocation("/");
 		return ;

--- a/srcs/server/HTTPResponseHandle.cpp
+++ b/srcs/server/HTTPResponseHandle.cpp
@@ -5,15 +5,27 @@ void HTTPResponse::selectResponse(HTTPRequest &request)
 	enum response_mode mode = request.getMode();
 	switch (mode) {
 	case NORMAL:
+	#ifdef DEBUG
+		std::cout << "########## [ DEBUG ] NORMAL ##########" << std::endl;
+	#endif
 		handleNormalRequest(request);
 		break;
 	case CGI:
+	#ifdef DEBUG
+		std::cout << "########## [ DEBUG ] CGI ##########" << std::endl;
+	#endif
 		handleCGIRequest(request);
 		break;
 	case AUTOINDEX:
+	#ifdef DEBUG
+		std::cout << "########## [ DEBUG ] AUTOINDEX ##########" << std::endl;
+	#endif
 		handleAutoIndexRequest(request);
 		break;
 	case REDIRECT:
+	#ifdef DEBUG
+		std::cout << "########## [ DEBUG ] REDIRECT ##########" << std::endl;
+	#endif
 		handleRedirectRequest(request);
 		break;
 	default:
@@ -53,10 +65,24 @@ void HTTPResponse::handleAutoIndexRequest(HTTPRequest &request)
 	std::cout << request.getUri() << std::endl;
 }
 
+// TODO : curlは成功、ブラウザはEAGAINでexitする
 void HTTPResponse::handleRedirectRequest(HTTPRequest &request)
 {
-	// TODO : redirectの処理
-	std::cout << request.getUri() << std::endl;
+	std::string uri = request.getUri();
+	std::string location = request.getLocation();
+	std::string path = "";
+	// TODO : configで設定されたredirectのpathを取得する
+	std::string redirect_path = "http://google.com";
+	// TODO : リダイレクトの後ろのパスも設定する場合
+	// size_t found = uri.find(location);
+	// if (found != std::string::npos) {
+	// 	path = uri.substr(found + location.size(), uri.size());
+	// }
+	// path = redirect_path + "/" + path;
+	path = redirect_path;
+	setHeader("Location", path);
+	setStatusCode(STATUS_301);
+	makeResponseMessage();
 }
 
 void HTTPResponse::handleErrorResponse(HTTPRequest &request)

--- a/srcs/server/Server.cpp
+++ b/srcs/server/Server.cpp
@@ -193,10 +193,12 @@ void Server::mainLoop(void)
 			continue;
 		}
 		for (int i = 0; i < MAX_CLIENTS; ++i) {
-			if (fds_[i].fd != -1 && (fds_[i].revents & (POLLIN | POLLERR))) {
+			if (fds_[i].fd != -1 && (fds_[i].revents & (POLLIN))) {
+				std::cout << "File descriptor " << fds_[i].fd << " is ready for reading." << std::endl;
 				client_fd = acceptSocket(fds_[i].fd);
 				if (client_fd < 0) {
 					if (errno == EWOULDBLOCK || errno == EAGAIN) {
+						errno = 0;
 						continue;
 					} else {
 						closeServerFds();


### PR DESCRIPTION
## Task・Issue
- #23 
-


## 実装したこと
- 実装方針・参考資料など
- redirectを定数で実装

## 動作確認
- テストケース・スクリーンショットなど
- /redirect/にアクセスするとレスポンスが帰ってくる
- curlは成功しているように見える
- ブラウザでやると成功はするが、EAGAINのerrnoでrecvでexitしてしまう。これはtelnetと同じ現象なので別で修正する。
- /redirect/hogehogeはすべてlocationのurlに飛ばす。
- /redirectはファイル扱いでエラー
