### PR TITLE
[Fix] 複数ホスト対応

### DIFF
--- a/config/multi.conf
+++ b/config/multi.conf
@@ -2,21 +2,18 @@
 server {
     listen 4242;
     server_name webserv1;
+    error_page ./www/error_page/404.html;
+    max_body_size 4000;
 
-    #index index.html index.php;
-
-    location /	 {     
-		alias ./docs/; 
+    location /	 {
+		alias ./www/;
+        index index.html;
+        method GET POST DELETE;
 	}
 
     location /autoindex/ {
-        alias ./docs/autoindex/; 
+        alias ./www/autoindex/;
 		autoindex on;
-    } 
-	
-	location /dir/ {
-        alias ./docs/dir/;
-        index hello.html;
     }
 
     location /cgi/ {
@@ -24,39 +21,32 @@ server {
         cgi_extension .php .pl;
     }
 
-    location /error_page/ {
-        alias ./docs/error_page/;
-        #error_page 404 /error_page/404.html;
-    }
-
     location /redirect/ {
         redir_path http://google.com;
     }
 
     location /upload/ {
-        alias ./docs/upload/;
-        upload_path ./docs/upload/;
+        upload_path ./www/upload/;
+    }
+}
+
+server {
+    listen 4242;
+    server_name webserv2;
+    location / {
+        alias ./www/dir/;
+        index index.html;
+        method GET POST DELETE;
     }
 }
 
 server {
     listen 4243;
     server_name webserv3;
-
     location / {
-        alias ./docs/Dir/;
-        index hello.html;
-    }
-}
-
-# server No.2
-server {
-    listen 4242;
-    server_name webserv2;
-
-    location / {
-        alias ./docs/Dir/;
-        index hello.html;
+        alias ./www/dir/;
+        index index.html;
+        method GET POST DELETE;
     }
 }
 

--- a/srcs/server/Server.cpp
+++ b/srcs/server/Server.cpp
@@ -159,7 +159,7 @@ void Server::executeSendProcess(std::map<int, Client*>::iterator &it)
 	int config_index = 0;
 	for (int i = 0;i < static_cast<int>(_servers[ft_stoi(port)].size()); i++)
 	{
-		if (_servers[ft_stoi(port)][config_index].getServerName() == host) {
+		if (_servers[ft_stoi(port)][i].getServerName() == host) {
 			config_index = i;
 			break;
 		}


### PR DESCRIPTION
## Task・Issue
- [ URLなど ]
- #28 


## 実装したこと
- 実装方針・参考資料など
- 複数ホストに対応
- 4242portに複数のサーバーの設定がある場合、Host名を指定することでリソースを分けて使用できるようにした
- ホスト名がない場合そのポートの１つ目の設定が用いられる（vectorで追加してるからindex = 0 番目）

## 動作確認
- テストケース・スクリーンショットなど
-　GETのみcurl, telnetで確認した
- ブラウザでは解決できないから多分テスト出来ない
